### PR TITLE
added column 'create_user' to attach OwnerBehavior to

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@ default.
 FullCrud
 - Attribute labels gets a Yii::t('app', <label>) wrapper to make easier i18n possible (thyseus)
 - Chg: If a column is called <em> create_time, createtime, update_time, updatetime or timestamp </em> the CTimestampBehavior shipped with zii will automatically added as a behavior (thyseus)
-- Chg: If a column is called <em> created_by, createdby, user, user_id, owner or owner_id </em> the OwnerBehavior shipped with the gii-template-collection will automatically added as a behavior (thyseus)
+- Chg: If a column is called <em> created_by, createdby, create_user, user, user_id, owner or owner_id </em> the OwnerBehavior shipped with the gii-template-collection will automatically added as a behavior (thyseus)
 - Chg: Removed GHelper (schmunk)
 - Enh: Added model relations to view templates (schmunk)
 - Enh: Added demo schema (MySQL) (schmunk)

--- a/components/OwnerBehavior.php
+++ b/components/OwnerBehavior.php
@@ -27,7 +27,7 @@ class OwnerBehavior extends CActiveRecordBehavior {
 		return true;
 	}
 
-	public function beforeSave() {
+	public function beforeSave($on) {
 
 		if(isset($this->owner->tableSchema->columns[$this->lastChangeColumn]))
 			$this->owner->{$this->lastChangeColumn} = Yii::app()->user->id;

--- a/fullModel/FullModelCode.php
+++ b/fullModel/FullModelCode.php
@@ -122,7 +122,8 @@ class FullModelCode extends ModelCode {
 										'ownerid',
 										'owner_id',
 										'created_by',
-										'createdby'))) {
+										'createdby',
+                                        'create_user'))) {
 							$behaviors .= sprintf("\n\t\t'OwnerBehavior' => array(
 								'class' => 'OwnerBehavior',
 							'ownerColumn' => '%s',

--- a/fullModel/templates/default/model.php
+++ b/fullModel/templates/default/model.php
@@ -83,7 +83,8 @@ class <?php echo $modelClass; ?> extends <?php echo 'Base' . $modelClass."\n"; ?
 										'ownerid',
 										'owner_id',
 										'created_by',
-										'createdby'))) {
+										'createdby',
+                                        'create_user'))) {
 							$behaviors .= sprintf("\n\t\t'OwnerBehavior' => array(
 								'class' => 'OwnerBehavior',
 							'ownerColumn' => '%s',

--- a/fullModel/views/index.php
+++ b/fullModel/views/index.php
@@ -53,7 +53,7 @@ default. </li>
 <li> All comments are removed except for the first comment describing the attributes of the model </li>
 <li> Attribute labels gets a Yii::t('app', <label>) wrapper to make easier i18n possible </li>
 <li> If a column is called <em> create_time, createtime, update_time, updatetime or timestamp </em> the CTimestampBehavior shipped with zii will automatically added as a behavior </li>
-<li> If a column is called <em> created_by, createdby, user, user_id, owner or owner_id </em> the OwnerBehavior shipped with the gii-template-collection will automatically added as a behavior </li>
+<li> If a column is called <em> created_by, createdby, create_user, user, user_id, owner or owner_id </em> the OwnerBehavior shipped with the gii-template-collection will automatically added as a behavior </li>
 
 </ul>
 


### PR DESCRIPTION
added column 'create_user' to attach OwnerBehavior to

The columns now are:
'user_id',
'userid',
'ownerid',
'owner_id',
'created_by',
'createdby',
'create_user'

AND also bugfixed OwnerBehavior::beforeSave().
